### PR TITLE
set required noise seed in the example notebook

### DIFF
--- a/example.ipynb
+++ b/example.ipynb
@@ -388,6 +388,7 @@
     "    'output_units' : 'uK_RJ',\n",
     "    'output_directory' : './',\n",
     "    'output_prefix' : 'test',\n",
+    "    'noise_seed' : 1234,\n",
     "}\n",
     "\n",
     "instrument = pysm.Instrument(instrument_bpass)\n",


### PR DESCRIPTION
I was running `example.ipynb` and got this error:

    Instrument attribute 'Noise_Seed' not set.

so I added `noise_seed` in the instrument configuration.
