### PR TITLE
Make changes to be Python 3 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
     - "2.7"
+    - "3.5"
+    - "3.6"
 install:
     - pip install --upgrade pip setuptools wheel
     - pip install -r requirements.txt

--- a/pysm/common.py
+++ b/pysm/common.py
@@ -71,9 +71,9 @@ def read_key(Class, keyword, dictionary):
     :returns: does not return, but modifies inputs.
     """
     try:
-	setattr(Class, '_%s__%s'%(Class.__class__.__name__, keyword), dictionary[keyword])
+        setattr(Class, '_%s__%s'%(Class.__class__.__name__, keyword), dictionary[keyword])
     except KeyError: 
-	print("%s not set."%keyword)
+        print("%s not set."%keyword)
     return
 
 def convert_units(unit1, unit2, nu):
@@ -89,76 +89,76 @@ def convert_units(unit1, unit2, nu):
     :returns: unit conversion coefficient - float, numpy.ndarray.
     """
     if "K_CMB" in unit1:
-	#first deal with the unit conversion
-	if "Jysr" in unit2:
-	    conversion_factor = K_CMB2Jysr(nu) 
-	elif "K_RJ" in unit2:
-	    conversion_factor = K_CMB2Jysr(nu) / K_RJ2Jysr(nu)
-	elif "K_CMB" in unit2:
-	    conversion_factor = np.ones_like(nu)
-	else:
-	    print("Incorrect format or unit.")
+        #first deal with the unit conversion
+        if "Jysr" in unit2:
+            conversion_factor = K_CMB2Jysr(nu) 
+        elif "K_RJ" in unit2:
+            conversion_factor = K_CMB2Jysr(nu) / K_RJ2Jysr(nu)
+        elif "K_CMB" in unit2:
+            conversion_factor = np.ones_like(nu)
+        else:
+            print("Incorrect format or unit.")
 
     elif "K_RJ" in unit1:
-	if "Jysr" in unit2:
-	    conversion_factor = K_RJ2Jysr(nu)
-	elif "K_CMB" in unit2:
-	    conversion_factor = K_RJ2Jysr(nu) / K_CMB2Jysr(nu)
-	elif "K_RJ" in unit2:
-	    conversion_factor = np.ones_like(nu)
-	else: 
-	    print("Incorrect format or unit.")
+        if "Jysr" in unit2:
+            conversion_factor = K_RJ2Jysr(nu)
+        elif "K_CMB" in unit2:
+            conversion_factor = K_RJ2Jysr(nu) / K_CMB2Jysr(nu)
+        elif "K_RJ" in unit2:
+            conversion_factor = np.ones_like(nu)
+        else: 
+            print("Incorrect format or unit.")
 
     elif "Jysr" in unit1:
-	if "Jysr" in unit2:
-	    conversion_factor = np.ones_like(nu)
-	elif "K_RJ" in unit2:
-	    conversion_factor = 1. / K_RJ2Jysr(nu)
-	elif "K_CMB" in unit2:
-	    conversion_factor = 1. / K_CMB2Jysr(nu)
-	else:
-	    print("Incorrect format or unit.")
+        if "Jysr" in unit2:
+            conversion_factor = np.ones_like(nu)
+        elif "K_RJ" in unit2:
+            conversion_factor = 1. / K_RJ2Jysr(nu)
+        elif "K_CMB" in unit2:
+            conversion_factor = 1. / K_CMB2Jysr(nu)
+        else:
+            print("Incorrect format or unit.")
 
     # Now deal with the magnitude
     if "n" in unit1[0]:
-	prefac = 1.e-9
+        prefac = 1.e-9
     elif "u" in unit1[0]:
-	prefac = 1.e-6
+        prefac = 1.e-6
     elif "m" in unit1[0]:
-	prefac = 1.e-3
+        prefac = 1.e-3
     elif "k" in unit1[0]:
-	prefac = 1.e3
+        prefac = 1.e3
     elif "M" in unit1[0]:
-	prefac = 1.e6
+        prefac = 1.e6
     elif "G" in unit1[0]:
-	prefac = 1.e9
+        prefac = 1.e9
     elif "K" in unit1[0]:
-	prefac = 1.
+        prefac = 1.
     elif "J" in unit1[0]:
-	prefac = 1.
+        prefac = 1.
     else:
-	print("Invalid format for unit1 in convert_units")
-	sys.exit(1)
+        print("Invalid format for unit1 in convert_units")
+        sys.exit(1)
 
     if "n" in unit2[0]:
-	postfac = 1.e9
+        postfac = 1.e9
     elif "u" in unit2[0]:
-	postfac = 1.e6
+        postfac = 1.e6
     elif "m" in unit2[0]:
-	postfac = 1.e3
+        postfac = 1.e3
     elif "k" in unit2[0]:
-	postfac = 1.e-3
+        postfac = 1.e-3
     elif "M" in unit2[0]:
-	postfac = 1.e-6
+        postfac = 1.e-6
     elif "G" in unit2[0]:
-	postfac = 1.e-9
+        postfac = 1.e-9
     elif "K" in unit2[0]:
-	postfac = 1.
+        postfac = 1.
     elif "J" in unit2[0]:
-	postfac = 1.
+        postfac = 1.
     else:
-	print("Invalid format for unit2 in convert_units")
-	sys.exit(1)
+        print("Invalid format for unit2 in convert_units")
+        sys.exit(1)
 
     return np.array(conversion_factor * prefac * postfac)
 
@@ -292,12 +292,12 @@ def invert_safe(m):
     mb = m.copy()
     w_ok = False
     while not w_ok :
-	w, v = np.linalg.eigh(mb)
-	wmin = np.min(w)
-	if wmin > 0:
-	    w_ok = True
-	else:
-	    mb += np.diag(2. * np.max([1E-14, -wmin]) * np.ones(len(mb)))
+        w, v = np.linalg.eigh(mb)
+        wmin = np.min(w)
+        if wmin > 0:
+            w_ok = True
+        else:
+            mb += np.diag(2. * np.max([1E-14, -wmin]) * np.ones(len(mb)))
     winv = 1. / w
     return np.dot(v, np.dot(np.diag(winv), np.transpose(v)))
         

--- a/pysm/common.py
+++ b/pysm/common.py
@@ -36,7 +36,7 @@ def FloatOrArray(model):
                     print("Frequencies must be float or convertable to 1d array.")
                     sys.exit(1)
                     """If it is 1d array evaluate model function over all its elements."""
-                return np.array(map(lambda x: model(x, **kwargs), list(nu_1darray)))
+                return np.array(list(map(lambda x: model(x, **kwargs), list(nu_1darray))))
             except ValueError:
                 """Fail if not convertable to 1d array"""
                 print("Frequencies must be either float or convertable to array.")

--- a/pysm/common.py
+++ b/pysm/common.py
@@ -6,6 +6,7 @@
 .. moduleauthor: Ben Thorne <ben.thorne@physics.ox.ac.uk>
 """
 
+from __future__ import print_function
 import healpy as hp
 import numpy as np
 import scipy.constants as constants
@@ -327,7 +328,7 @@ def tophat_bandpass(nu_c, delta_nu, samples = 50):
     """
     freqs = np.linspace(nu_c - delta_nu / 2., nu_c + delta_nu / 2., samples)
     weights = np.ones_like(freqs) / (freqs.size * delta_nu / samples)
-    print np.sum(weights * delta_nu)
+    print(np.sum(weights * delta_nu))
     return (freqs, weights)
 
 def plot_maps(ins_conf, plot_odir):

--- a/pysm/common.py
+++ b/pysm/common.py
@@ -36,7 +36,7 @@ def FloatOrArray(model):
                     print("Frequencies must be float or convertable to 1d array.")
                     sys.exit(1)
                     """If it is 1d array evaluate model function over all its elements."""
-                return np.array(list(map(lambda x: model(x, **kwargs), list(nu_1darray))))
+                return np.array([model(x, **kwargs) for x in nu_1darray])
             except ValueError:
                 """Fail if not convertable to 1d array"""
                 print("Frequencies must be either float or convertable to array.")
@@ -311,7 +311,7 @@ def check_lengths(*args):
     :return: True if lengths are equal, else False -- bool
 
     """
-    return (len(set(map(lambda x: len(x), args))) <= 1)
+    return (len(set([len(x) for x in args])) <= 1)
 
 def tophat_bandpass(nu_c, delta_nu, samples = 50):
     """Calculate a tophat bandpass for a given central frequency and width. 

--- a/pysm/components.py
+++ b/pysm/components.py
@@ -41,67 +41,67 @@ class Synchrotron(object):
 
     @property
     def Model(self):
-    	try:
+        try:
             return self.__model
-    	except AttributeError:
-    	    print("Synchrotron attribute 'Model' not set.")
-    	    sys.exit(1)
+        except AttributeError:
+            print("Synchrotron attribute 'Model' not set.")
+            sys.exit(1)
 
     @property
     def A_I(self):
-    	try:
+        try:
             return self.__A_I
         except AttributeError:
-    	    print("Synchrotron attribute 'A_I' not set.")
-    	    sys.exit(1)
+            print("Synchrotron attribute 'A_I' not set.")
+            sys.exit(1)
 
     @property
     def A_Q(self):
-    	try:
+        try:
             return self.__A_Q
         except AttributeError:
-    	    print("Synchrotron attribute 'A_Q' not set.")
-    	    sys.exit(1)
+            print("Synchrotron attribute 'A_Q' not set.")
+            sys.exit(1)
 
     @property
     def A_U(self):
-    	try:
+        try:
             return self.__A_U
         except AttributeError:
-    	    print("%s attribute 'A_U' not set.")
-    	    sys.exit(1)
+            print("%s attribute 'A_U' not set.")
+            sys.exit(1)
 
     @property
     def Nu_0_I(self):
-    	try:
+        try:
             return self.__nu_0_I
         except AttributeError:
-    	    print("Synchrotron attribute 'Nu_0_I' not set.")
-    	    sys.exit(1)
+            print("Synchrotron attribute 'Nu_0_I' not set.")
+            sys.exit(1)
 
     @property
     def Nu_0_P(self):
-    	try:
+        try:
             return self.__nu_0_P
         except AttributeError:
-    	    print("Synchrotron attribute 'Nu_0_P' not set.")
-    	    sys.exit(1)
+            print("Synchrotron attribute 'Nu_0_P' not set.")
+            sys.exit(1)
 
     @property
     def Spectral_Index(self):
-    	try:
+        try:
             return self.__spectral_index
         except AttributeError:
-    	    print("Synchrotron attribute 'Spectral_Index' not set.")
-    	    sys.exit(1)
+            print("Synchrotron attribute 'Spectral_Index' not set.")
+            sys.exit(1)
 
     @property
     def Spectral_Curvature(self):
-    	try:
+        try:
             return self.__spectral_curvature
-    	except AttributeError:
-    	    print("Synchrotron attribute 'Spectral_Curvature' not set.")
-    	    sys.exit(1)
+        except AttributeError:
+            print("Synchrotron attribute 'Spectral_Curvature' not set.")
+            sys.exit(1)
 
     @property
     def Nu_Curve(self):
@@ -199,67 +199,67 @@ class Dust(object):
 
     @property
     def Model(self):
-    	try:
+        try:
             return self.__model
-    	except AttributeError:
-    	    print("Dust attribute 'Model' not set.")
-    	    sys.exit(1)
+        except AttributeError:
+            print("Dust attribute 'Model' not set.")
+            sys.exit(1)
 
     @property
     def A_I(self):
-    	try:
+        try:
             return self.__A_I
         except AttributeError:
-    	    print("Dust attribute 'A_I' not set.")
-    	    sys.exit(1)
+            print("Dust attribute 'A_I' not set.")
+            sys.exit(1)
 
     @property
     def A_Q(self):
-    	try:
+        try:
             return self.__A_Q
         except AttributeError:
-    	    print("Dust attribute 'A_Q' not set.")
-    	    sys.exit(1)
+            print("Dust attribute 'A_Q' not set.")
+            sys.exit(1)
 
     @property
     def A_U(self):
-    	try:
+        try:
             return self.__A_U
         except AttributeError:
-    	    print("Dust attribute 'A_U' not set.")
-    	    sys.exit(1)
+            print("Dust attribute 'A_U' not set.")
+            sys.exit(1)
 
     @property
     def Nu_0_I(self):
-    	try:
+        try:
             return self.__nu_0_I
         except AttributeError:
-    	    print("Dust attribute 'Nu_0_I' not set.")
-    	    sys.exit(1)
+            print("Dust attribute 'Nu_0_I' not set.")
+            sys.exit(1)
 
     @property
     def Nu_0_P(self):
-    	try:
-    	    return self.__nu_0_P
+        try:
+            return self.__nu_0_P
         except AttributeError:
-    	    print("Dust attribute 'Nu_0_P' not set.")
-    	    sys.exit(1)
+            print("Dust attribute 'Nu_0_P' not set.")
+            sys.exit(1)
 
     @property
     def Spectral_Index(self):
-    	try:
-	    return self.__spectral_index
+        try:
+            return self.__spectral_index
         except AttributeError:
-    	    print("Dust attribute 'Spectral_Index' not set.")
-    	    sys.exit(1)
+            print("Dust attribute 'Spectral_Index' not set.")
+            sys.exit(1)
 
     @property
     def Temp(self):
-    	try:
+        try:
             return self.__temp
         except AttributeError:
-    	    print("Dust attribute 'Temp' not set.")
-    	    sys.exit(1)
+            print("Dust attribute 'Temp' not set.")
+            sys.exit(1)
 
     @property
     def Uval(self):
@@ -544,43 +544,43 @@ class AME(object):
 
     @property
     def Emissivity(self):
-    	try:
+        try:
             return self.__emissivity
         except AttributeError:
-    	    print("AME attribute 'Emissivity' not set.")
-    	    sys.exit(1)
+            print("AME attribute 'Emissivity' not set.")
+            sys.exit(1)
 
     @property
     def Model(self):
-	try:
-	    return self.__model
-	except AttributeError:
-	    print("AME attribute 'Model' not set.")
-	    sys.exit(1)
+        try:
+            return self.__model
+        except AttributeError:
+            print("AME attribute 'Model' not set.")
+            sys.exit(1)
 
     @property
     def Nu_0_I(self):
-    	try:
+        try:
             return self.__nu_0_I
         except AttributeError:
-    	    print("AME attribute 'Nu_0_I' not set.")
-    	    sys.exit(1)
+            print("AME attribute 'Nu_0_I' not set.")
+            sys.exit(1)
 
     @property
     def Nu_Peak(self):
-    	try:
+        try:
             return self.__nu_peak
         except AttributeError:
-    	    print("AME attribute 'Nu_Peak' not set.")
-    	    sys.exit(1)
+            print("AME attribute 'Nu_Peak' not set.")
+            sys.exit(1)
 
     @property
     def Nu_Peak_0(self):
-    	try:
+        try:
             return self.__nu_peak_0
-    	except AttributeError:
-    	    print("AME attribute 'Nu_Peak_0' not set.")
-    	    sys.exit(1)
+        except AttributeError:
+            print("AME attribute 'Nu_Peak_0' not set.")
+            sys.exit(1)
 
     @property
     def Angle_Q(self):
@@ -600,11 +600,11 @@ class AME(object):
 
     @property
     def Pol_Frac(self):
-    	try:
-    	    return self.__pol_frac
-    	except AttributeError:
-    	    print("AME attribute 'Pol_Frac' not set.")
-    	    sys.exit(1)
+        try:
+            return self.__pol_frac
+        except AttributeError:
+            print("AME attribute 'Pol_Frac' not set.")
+            sys.exit(1)
 
     def signal(self):
         """Function to return the selected SED.
@@ -624,7 +624,7 @@ class AME(object):
         :return: spdust SED - float.
 
         """
-    	J = interp1d(self.Emissivity[0], self.Emissivity[1], bounds_error = False, fill_value = 0)
+        J = interp1d(self.Emissivity[0], self.Emissivity[1], bounds_error = False, fill_value = 0)
         arg1 = nu * self.Nu_Peak_0 / self.Nu_Peak
         arg2 = self.Nu_0_I * self.Nu_Peak_0 / self.Nu_Peak
         scaling = ((self.Nu_0_I / nu) ** 2) * (J(arg1) / J(arg2))
@@ -658,7 +658,7 @@ class AME(object):
         :return: function -- polarised spdust2 model as a function of frequency.
         """
         @FloatOrArray
-    	def model(nu, **kwargs):
+        def model(nu, **kwargs):
             """We use input Q and U from dust templates in order to make the
             polarisation angle consistent after down or up grading
             resolution. Downgrading polarisatoin angle templates gives
@@ -671,10 +671,10 @@ class AME(object):
 
             """
             pol_angle = np.arctan2(self.Angle_U, self.Angle_Q)
-    	    A_Q = self.A_I * self.Pol_Frac * np.cos(pol_angle)
-    	    A_U = self.A_I * self.Pol_Frac * np.sin(pol_angle)
-    	    return self.spdust_scaling(nu) * np.array([self.A_I, A_Q, A_U])
-    	return model
+            A_Q = self.A_I * self.Pol_Frac * np.cos(pol_angle)
+            A_U = self.A_I * self.Pol_Frac * np.sin(pol_angle)
+            return self.spdust_scaling(nu) * np.array([self.A_I, A_Q, A_U])
+        return model
 
 class Freefree(object):
     """Class defining attributes and scaling laws of the free-free
@@ -691,48 +691,48 @@ class Freefree(object):
 
     """
     def __init__(self, config):
-	for k in config.keys():
-	    read_key(self, k, config)
-	return
+        for k in config.keys():
+            read_key(self, k, config)
+        return
 
     @property
     def Model(self):
-	try:
-	    return self.__model
-	except AttributeError:
-	    print("Freefree attribute 'Model' not set.")
-	    sys.exit(1)
+        try:
+            return self.__model
+        except AttributeError:
+            print("Freefree attribute 'Model' not set.")
+            sys.exit(1)
 
     @property
     def A_I(self):
-	try:
-	    return self.__A_I
-	except AttributeError:
-	    print("Freefree attribute 'A_I' not set.")
-	    sys.exit(1)
+        try:
+            return self.__A_I
+        except AttributeError:
+            print("Freefree attribute 'A_I' not set.")
+            sys.exit(1)
 
     @property
     def Nu_0_I(self):
-	try:
-	    return self.__nu_0_I
-	except AttributeError:
-	    print("Freefree attribute 'Nu_0_I' not set.")
-	    sys.exit(1)
+        try:
+            return self.__nu_0_I
+        except AttributeError:
+            print("Freefree attribute 'Nu_0_I' not set.")
+            sys.exit(1)
 
     @property
     def Spectral_Index(self):
-	try:
-	    return self.__spectral_index
-	except AttributeError:
-	    print("Freefree attribute 'Spectral_Index' not set.")
-	    sys.exit(1)
+        try:
+            return self.__spectral_index
+        except AttributeError:
+            print("Freefree attribute 'Spectral_Index' not set.")
+            sys.exit(1)
 
     def signal(self):
         """Function to return the selected SED.
 
         :return: function -- selected scaling model.
         """
-	return getattr(self, self.Model)()
+        return getattr(self, self.Model)()
 
     def power_law(self):
         """Returns synchrotron (T, Q, U) maps as a function of observation
@@ -746,7 +746,7 @@ class Freefree(object):
 
         """
         @FloatOrArray
-	def model(nu, **kwargs):
+        def model(nu, **kwargs):
             """Power law scaling model.
 
             :param nu: frequency at which to calculate the map.
@@ -754,10 +754,10 @@ class Freefree(object):
             :return: numpy.ndarray -- power law scaled maps, shape (3, Npix).
 
             """
-	    scaling = power_law(nu, self.Nu_0_I, self.Spectral_Index)
-	    zeros = np.zeros_like(self.A_I)
-	    return np.array([self.A_I * scaling, zeros, zeros])
-	return model
+            scaling = power_law(nu, self.Nu_0_I, self.Spectral_Index)
+            zeros = np.zeros_like(self.A_I)
+            return np.array([self.A_I * scaling, zeros, zeros])
+        return model
 
 class CMB(object):
     """Class defining attributes and scaling laws of the synchrotron
@@ -875,63 +875,63 @@ class CMB(object):
 
         :return: function -- CMB maps.
         """
-    	synlmax = 8 * self.Nside #this used to be user-defined.
-    	data = self.CMB_Specs
-    	lmax_cl = len(data[0]) + 1
-    	l = np.arange(int(lmax_cl + 1))
-    	synlmax = min(synlmax, l[-1])
+        synlmax = 8 * self.Nside #this used to be user-defined.
+        data = self.CMB_Specs
+        lmax_cl = len(data[0]) + 1
+        l = np.arange(int(lmax_cl + 1))
+        synlmax = min(synlmax, l[-1])
 
-    	#Reading input spectra in CAMB format. CAMB outputs l(l+1)/2pi hence the corrections.
-    	cl_tebp_arr=np.zeros([10, lmax_cl + 1])
-    	cl_tebp_arr[0, 2:] = 2 * np.pi * data[1] / (l[2:] * (l[2:] + 1))    #TT
-    	cl_tebp_arr[1, 2:] = 2 * np.pi * data[2] / (l[2:] * (l[2:] + 1))    #EE
-    	cl_tebp_arr[2, 2:] = 2 * np.pi * data[3] / (l[2:] * (l[2:] + 1))    #BB
-    	cl_tebp_arr[4, 2:] = 2 * np.pi * data[4] / (l[2:] * (l[2:] + 1))    #TE
-    	cl_tebp_arr[5, :] = np.zeros(lmax_cl + 1)           				#EB
-    	cl_tebp_arr[7, :] = np.zeros(lmax_cl + 1)                    		#TB
+        #Reading input spectra in CAMB format. CAMB outputs l(l+1)/2pi hence the corrections.
+        cl_tebp_arr=np.zeros([10, lmax_cl + 1])
+        cl_tebp_arr[0, 2:] = 2 * np.pi * data[1] / (l[2:] * (l[2:] + 1))    #TT
+        cl_tebp_arr[1, 2:] = 2 * np.pi * data[2] / (l[2:] * (l[2:] + 1))    #EE
+        cl_tebp_arr[2, 2:] = 2 * np.pi * data[3] / (l[2:] * (l[2:] + 1))    #BB
+        cl_tebp_arr[4, 2:] = 2 * np.pi * data[4] / (l[2:] * (l[2:] + 1))    #TE
+        cl_tebp_arr[5, :] = np.zeros(lmax_cl + 1)                           #EB
+        cl_tebp_arr[7, :] = np.zeros(lmax_cl + 1)                           #TB
 
-    	if self.Delens:
-    	    cl_tebp_arr[3, 2:] = 2 * np.pi * data[5] * self.Delensing_Ells[1] / (l[2:] * (l[2:] + 1)) ** 2   			#PP
-    	    cl_tebp_arr[6,:] = np.zeros(lmax_cl + 1)                    												#BP
-    	    cl_tebp_arr[8, 2:] = 2 * np.pi * data[7] * np.sqrt(self.Delensing_Ells[1]) / (l[2:] * (l[2:] + 1)) ** 1.5   #EP
-    	    cl_tebp_arr[9, 2:] = 2 * np.pi * data[6] * np.sqrt(self.Delensing_Ells[1]) / (l[2:] * (l[2:] + 1)) ** 1.5  	#TP
-    	else:
-    	    cl_tebp_arr[3,2:] = 2 * np.pi * data[5] / (l[2:] * (l[2:] + 1)) ** 2   	#PP
-    	    cl_tebp_arr[6,:] =np.zeros(lmax_cl+1)                    				#BP
-    	    cl_tebp_arr[8,2:] = 2 * np.pi * data[7] / (l[2:] * (l[2:] + 1)) ** 1.5 	#EP
-    	    cl_tebp_arr[9,2:] = 2 * np.pi * data[6] / (l[2:] * (l[2:] + 1)) ** 1.5 	#TP
+        if self.Delens:
+            cl_tebp_arr[3, 2:] = 2 * np.pi * data[5] * self.Delensing_Ells[1] / (l[2:] * (l[2:] + 1)) ** 2              #PP
+            cl_tebp_arr[6,:] = np.zeros(lmax_cl + 1)                                                                    #BP
+            cl_tebp_arr[8, 2:] = 2 * np.pi * data[7] * np.sqrt(self.Delensing_Ells[1]) / (l[2:] * (l[2:] + 1)) ** 1.5   #EP
+            cl_tebp_arr[9, 2:] = 2 * np.pi * data[6] * np.sqrt(self.Delensing_Ells[1]) / (l[2:] * (l[2:] + 1)) ** 1.5   #TP
+        else:
+            cl_tebp_arr[3,2:] = 2 * np.pi * data[5] / (l[2:] * (l[2:] + 1)) ** 2        #PP
+            cl_tebp_arr[6,:] =np.zeros(lmax_cl+1)                                       #BP
+            cl_tebp_arr[8,2:] = 2 * np.pi * data[7] / (l[2:] * (l[2:] + 1)) ** 1.5      #EP
+            cl_tebp_arr[9,2:] = 2 * np.pi * data[6] / (l[2:] * (l[2:] + 1)) ** 1.5      #TP
 
-    	# Coordinates of healpix pixel centers
-    	ipos = np.array(hp.pix2ang(self.Nside, np.arange(12 * (self.Nside ** 2))))
+        # Coordinates of healpix pixel centers
+        ipos = np.array(hp.pix2ang(self.Nside, np.arange(12 * (self.Nside ** 2))))
 
-    	# Simulate a CMB and lensing field
-    	cmb, aphi = simulate_tebp_correlated(cl_tebp_arr, self.Nside, synlmax, self.CMB_Seed)
+        # Simulate a CMB and lensing field
+        cmb, aphi = simulate_tebp_correlated(cl_tebp_arr, self.Nside, synlmax, self.CMB_Seed)
 
-    	if cmb.ndim == 1:
-    	    cmb = np.reshape(cmb, [1, cmb.size])
+        if cmb.ndim == 1:
+            cmb = np.reshape(cmb, [1, cmb.size])
 
-    	# Compute the offset positions
-    	phi, phi_dtheta, phi_dphi = hp.alm2map_der1(aphi, self.Nside, lmax = synlmax)
+        # Compute the offset positions
+        phi, phi_dtheta, phi_dphi = hp.alm2map_der1(aphi, self.Nside, lmax = synlmax)
 
-    	del aphi
+        del aphi
 
-    	opos, rot = offset_pos(ipos, phi_dtheta, phi_dphi, pol=True, geodesic=False) #geodesic used to be used defined.
-    	del phi, phi_dtheta, phi_dphi
+        opos, rot = offset_pos(ipos, phi_dtheta, phi_dphi, pol=True, geodesic=False) #geodesic used to be used defined.
+        del phi, phi_dtheta, phi_dphi
 
-    	# Interpolate maps one at a time
-    	maps  = []
-    	for comp in cmb:
-    	    for m in taylor_interpol_iter(comp, opos, 3, verbose=False, lmax=None): #lmax here needs to be fixed. order of taylor expansion is fixed to 3.
-    		pass
-    	    maps.append(m)
-    	del opos, cmb
-    	#save the map computed for future referemce.
-    	rm = apply_rotation(maps, rot)
+        # Interpolate maps one at a time
+        maps  = []
+        for comp in cmb:
+            for m in taylor_interpol_iter(comp, opos, 3, verbose=False, lmax=None): #lmax here needs to be fixed. order of taylor expansion is fixed to 3.
+                pass
+            maps.append(m)
+        del opos, cmb
+        #save the map computed for future referemce.
+        rm = apply_rotation(maps, rot)
 
         @FloatOrArray
-    	def model(nu, **kwargs):
-    	    return np.array(rm) * convert_units("uK_CMB", "uK_RJ", nu)
-    	return model
+        def model(nu, **kwargs):
+            return np.array(rm) * convert_units("uK_CMB", "uK_RJ", nu)
+        return model
 
     def synfast(self):
         """Function for the calculation of lensed CMB maps directly from
@@ -939,9 +939,9 @@ class CMB(object):
         """
         # get the spectra. These are in CAMB format, we discard the last
         # three corresponding to dd, dt, de, respectively.
-    	ell, tt, ee, bb, te, _, _, _ = self.CMB_Specs
-    	lmax_cl = len(ell) + 1
-    	ell = np.arange(lmax_cl + 1)
+        ell, tt, ee, bb, te, _, _, _ = self.CMB_Specs
+        lmax_cl = len(ell) + 1
+        ell = np.arange(lmax_cl + 1)
 
         # in CAMB format so we must divide by the scaling factor
         factor = ell * (ell + 1.) / 2. / np.pi
@@ -970,8 +970,8 @@ class CMB(object):
 
         """
         @FloatOrArray
-    	def model(nu, **kwargs):
-    	    return np.array([self.A_I, self.A_Q, self.A_U]) * convert_units("uK_CMB", "uK_RJ", nu)
+        def model(nu, **kwargs):
+            return np.array([self.A_I, self.A_Q, self.A_U]) * convert_units("uK_CMB", "uK_RJ", nu)
         return model
 
 def power_law(nu, nu_0, b):
@@ -1115,19 +1115,19 @@ https://github.com/amaurea/taylens
 
 """
 def simulate_tebp_correlated(cl_tebp_arr, nside, lmax, seed):
-	"""This generates correlated T,E,B and Phi maps
+        """This generates correlated T,E,B and Phi maps
 
         """
-	np.random.seed(seed)
-	alms=hp.synalm(cl_tebp_arr, lmax = lmax, new = True)
-	aphi=alms[-1]
-	acmb=alms[0 : -1]
-	#Set to zero above map resolution to avoid aliasing
-	beam_cut=np.ones(3 * nside)
-	for ac in acmb:
-		hp.almxfl(ac, beam_cut, inplace = True)
-	cmb=np.array(hp.alm2map(acmb, nside, pol = True, verbose = False))
-	return cmb, aphi
+        np.random.seed(seed)
+        alms=hp.synalm(cl_tebp_arr, lmax = lmax, new = True)
+        aphi=alms[-1]
+        acmb=alms[0 : -1]
+        #Set to zero above map resolution to avoid aliasing
+        beam_cut=np.ones(3 * nside)
+        for ac in acmb:
+                hp.almxfl(ac, beam_cut, inplace = True)
+        cmb=np.array(hp.alm2map(acmb, nside, pol = True, verbose = False))
+        return cmb, aphi
 
 def taylor_interpol_iter(m, pos, order=3, verbose=False, lmax=None):
     """Given a healpix map m[npix], and a set of positions
@@ -1140,7 +1140,7 @@ def taylor_interpol_iter(m, pos, order=3, verbose=False, lmax=None):
     """
     nside = hp.npix2nside(m.size)
     if lmax is None:
-    	lmax = 3 * nside
+        lmax = 3 * nside
     # Find the healpix pixel centers closest to pos,
     # and our deviation from these pixel centers.
     ipos = hp.ang2pix(nside, pos[0], pos[1])
@@ -1184,7 +1184,7 @@ def taylor_interpol_iter(m, pos, order=3, verbose=False, lmax=None):
                     # Use these to compute the next level
                     for j in range(i, min(i + 2, o + 1)):
                             if used[j]:
-                            	continue
+                                continue
                             N = comb(o, j) / factorial(o)
                             res += N * derivs2[j][ipos] * dpos[0]**(o-j) * dpos[1]**j
                             used[j] = True
@@ -1228,9 +1228,9 @@ def offset_pos(ipos, dtheta, dphi, pol=False, geodesic=False):
     """
     opos = np.zeros(ipos.shape)
     if pol and not geodesic:
-    	orot = np.zeros(ipos.shape)
+        orot = np.zeros(ipos.shape)
     else:
-    	orot = None
+        orot = None
     if not geodesic:
             # Loop over chunks in order to conserve memory
             step = 0x10000
@@ -1281,9 +1281,9 @@ def apply_rotation(m, rot):
 
     """
     if len(m) < 3:
-    	return m
+        return m
     if rot is None:
-    	return m
+        return m
     m = np.asarray(m)
     res = m.copy()
     res[1] = rot[0] * m[1] - rot[1] * m[2]
@@ -1293,10 +1293,10 @@ def apply_rotation(m, rot):
 # Set up progress prints
 t0 = None
 def silent(msg):
-	pass
+        pass
 
 def tprint(msg):
         global t0
         if t0 is None:
-        	t0 = time.time()
+                t0 = time.time()
         print >> sys.stderr, "%8.2f %s" % (time.time() - t0, msg)

--- a/pysm/components.py
+++ b/pysm/components.py
@@ -6,15 +6,15 @@
 .. moduleauthor: Ben Thorne <ben.thorne@physics.ox.ac.uk>
 """
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 import numpy as np
 import healpy as hp
 import os, sys, time
 import scipy.constants as constants
 from scipy.interpolate import interp1d, RectBivariateSpline
 from scipy.misc import factorial, comb
-from common import read_key, convert_units, FloatOrArray, invert_safe, B
-from nominal import template
+from .common import read_key, convert_units, FloatOrArray, invert_safe, B
+from .nominal import template
 
 class Synchrotron(object):
     """Class defining attributes and scaling laws of the synchrotron

--- a/pysm/components.py
+++ b/pysm/components.py
@@ -6,6 +6,7 @@
 .. moduleauthor: Ben Thorne <ben.thorne@physics.ox.ac.uk>
 """
 
+from __future__ import print_function
 import numpy as np
 import healpy as hp
 import os, sys, time
@@ -1299,4 +1300,4 @@ def tprint(msg):
         global t0
         if t0 is None:
                 t0 = time.time()
-        print >> sys.stderr, "%8.2f %s" % (time.time() - t0, msg)
+        print("%8.2f %s" % (time.time() - t0, msg), file=sys.stderr)

--- a/pysm/nominal.py
+++ b/pysm/nominal.py
@@ -1,4 +1,5 @@
-from common import read_map
+from __future__ import absolute_import
+from .common import read_map
 import numpy as np
 from healpy import nside2npix
 import os

--- a/pysm/pysm.py
+++ b/pysm/pysm.py
@@ -61,7 +61,7 @@ class Sky(object):
         components.
         """
         self.__config = config
-        self.__components = config.keys()
+        self.__components = list(config.keys())
 
         if 'cmb' in self.Components:
             self.cmb = component_adder(CMB, self.Config['cmb'])
@@ -350,7 +350,7 @@ class Instrument(object):
             # class was first instantiated, if use_bandpass = True. Note that the dust signal will still contribute
             # to the bpass_integrated sum in the evaluation above, but will be zero.
             if Sky.Uses_HD17:
-                bpass_integrated += np.array(map(Sky.HD_17_bpass, self.Channels))
+                bpass_integrated += np.array(list(map(Sky.HD_17_bpass, self.Channels)))
             return bpass_integrated
         else:
             print("Please set 'Use_Bandpass' for Instrument object.")
@@ -431,14 +431,14 @@ class Instrument(object):
         elif self.Use_Bandpass:
             # In the case of a given bandpass we calculate the unit conversion as explained in the documentation
             # of bandpass_convert_units. 
-            Uc_signal = np.array(map(lambda channel: bandpass_convert_units(self.Output_Units, channel), self.Channels))
+            Uc_signal = np.array([bandpass_convert_units(self.Output_Units, channel) for channel in self.Channels])
         if self.Add_Noise:
             # If noise requested also multiple the calculated noise.
             if not self.Use_Bandpass:
                 Uc_noise = np.array(convert_units("uK_CMB", self.Output_Units, self.Frequencies))
             elif self.Use_Bandpass:
                 # first convert noise to Jysr then apply the same unit conversion as used for the signal.
-                Uc_noise = Uc_signal * np.array(map(lambda channel: 1. / bandpass_convert_units("uK_CMB", channel), self.Channels))
+                Uc_noise = Uc_signal * np.array([1. / bandpass_convert_units("uK_CMB", channel) for channel in self.Channels])
         elif not self.Add_Noise:
             Uc_noise = np.zeros_like(Uc_signal)
         return Uc_signal[:, None, None] * map_array, Uc_noise[:, None, None] * noise
@@ -557,7 +557,7 @@ def component_adder(component_class, dictionary_list, **kwargs):
     # each dictionary is a configuration dict used to
     # instantiate the component's class. We then take the
     # signal produced by that population.
-    population_signals = map(lambda dic: component_class(dic).signal(**kwargs), dictionary_list)
+    population_signals = [component_class(dic).signal(**kwargs) for dic in dictionary_list]
     # sigs is now a list of functions. Each function is the emission
     # due to a population of the component.
     def total_signal(nu, **kwargs):

--- a/pysm/pysm.py
+++ b/pysm/pysm.py
@@ -6,6 +6,7 @@
 .. moduleauthor: Ben Thorne <ben.thorne@physics.ox.ac.uk> 
 """
 
+from __future__ import print_function
 from scipy import interpolate, integrate
 import numpy as np
 import healpy as hp
@@ -459,8 +460,8 @@ class Instrument(object):
         if not self.Use_Bandpass:
             if self.Add_Noise:
                 for f, o, n in zip(self.Frequencies, output, noise):
-                    print np.std(n, axis = 1)# * np.sqrt(4. * np.pi / float(hp.nside2npix(128)) * (180. * 60. / np.pi) ** 2)
-                    print np.std(o, axis = 1)
+                    print(np.std(n, axis = 1))# * np.sqrt(4. * np.pi / float(hp.nside2npix(128)) * (180. * 60. / np.pi) ** 2)
+                    print(np.std(o, axis = 1))
                     hp.write_map(self.file_path(f = f, extra_info = "noise"), n)
                     hp.write_map(self.file_path(f = f, extra_info = "total"), o + n)
             elif not self.Add_Noise:

--- a/pysm/pysm.py
+++ b/pysm/pysm.py
@@ -6,14 +6,14 @@
 .. moduleauthor: Ben Thorne <ben.thorne@physics.ox.ac.uk> 
 """
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 from scipy import interpolate, integrate
 import numpy as np
 import healpy as hp
 import scipy.constants as constants
 import os, sys
-from components import Dust, Synchrotron, Freefree, AME, CMB
-from common import read_key, convert_units, bandpass_convert_units, check_lengths
+from .components import Dust, Synchrotron, Freefree, AME, CMB
+from .common import read_key, convert_units, bandpass_convert_units, check_lengths
 
 class Sky(object):
     """Model sky signal of Galactic foregrounds.

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -81,16 +81,16 @@ class test_Bandpass_Unit_Conversion(unittest.TestCase):
         # Read in the fits file. This contains only the HFI frequencies 100 -> 857.
         planck_HFI_file = os.path.join(os.path.abspath(os.path.dirname(__file__)), "test_data" , "HFI_RIMO_R1.10.fits")
         hdu = fits.open(planck_HFI_file)
-        bandpasses = map(lambda i: hdu[i].data, range(2, 8))
+        bandpasses = [hdu[i].data for i in range(2, 8)]
         # The table contains 4 lists: wavenumber, transmission, 1-sigma uncertainty, flag.
         # We are only interested in wavenumber and transmission.
         channels = []
         for b in bandpasses:
-            wavenumber, transmission, _, _ = zip(*b)
+            wavenumber, transmission, _, _ = list(zip(*b))
             frequency = 1e-7 * constants.c * np.array(wavenumber)
             # exclude the element frqeuency[0] = 0
             filt = lambda x: (x[0] > 1.) & (x[0] < 1200)
-            freqs, weights = zip(*filter(filt, zip(frequency, transmission)))
+            freqs, weights = list(zip(*filter(filt, zip(frequency, transmission))))
             channels.append((np.array(freqs), np.array(weights)))
             
         """Planck-provided coefficients for K_CMB to MJysr.

--- a/test/test_data/checks.py
+++ b/test/test_data/checks.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 import healpy as hp
 import subprocess
@@ -31,13 +32,13 @@ def compare_maps(component,i_check) :
     return 1
 
 def run_check(i_check,component) :
-    print "Running check %d..."%i_check
+    print("Running check %d..."%i_check)
     os.system('python main.py test/check%d_config.ini > log_checks 2>&1'%i_check)
     passed=compare_maps(component,i_check)
     if passed :
-        print bcolors.OKGREEN+"   PASSED"+bcolors.ENDC
+        print(bcolors.OKGREEN+"   PASSED"+bcolors.ENDC)
     else :
-        print bcolors.FAIL+"   FAILED"+bcolors.ENDC
+        print(bcolors.FAIL+"   FAILED"+bcolors.ENDC)
     subprocess.call(['rm', '-r', 'test/Output'])
     return passed
 
@@ -45,4 +46,4 @@ n_passed=0; n_total=0
 for i_check,component in zip([1,2,3,4,5,6,7,8,9,10,11],['therm','synch','spinn','freef','cmb', 'therm', 'synch', 'spinn', 'therm', 'synch', 'therm']) :
     n_passed+=run_check(i_check,component)
     n_total+=1
-print "%d tests passed "%n_passed+"out of %d"%n_total
+print("%d tests passed "%n_passed+"out of %d"%n_total)


### PR DESCRIPTION
While helping my advisor get PySM running, I found a few instances where syntax or usage restricted me to proceeding with a Python 2.7 instance. This PR includes the obvious (but probably sub-optimal) changes I made to get the installation and `nosetests` commands to complete without errors. Testing on a Python 2.7 instance also still worked (but my Python knowledge is pretty basic, so I don't know if I've made changes that make 2.6 and earlier now break).

Specifically, Python 2.7.6 and Python 3.6.1 with packages:
```
numpy = 1.13.0
scipy = 0.19.1
matplotlib = 2.0.2
sphinx = 1.6.3
nose = 1.3.7
healpy = 1.10.3
```