### PR TITLE
[WIP] Implementation of partial sky support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,7 @@ ENV/
 
 # mkdocs documentation
 /site
+
+# vim
+.swp
+.swo

--- a/pysm/common.py
+++ b/pysm/common.py
@@ -43,7 +43,7 @@ def FloatOrArray(model):
                 sys.exit(1)
     return decorator
 
-def read_map(fname, nside, field = (0), verbose = False):
+def read_map(fname, nside, field = (0), pixel_indices=None, verbose = False):
     """Convenience function wrapping healpy's read_map and upgrade /
     downgrade in one function.
     
@@ -53,11 +53,20 @@ def read_map(fname, nside, field = (0), verbose = False):
     :type nside: int.  
     :param field: fields of fits file from which to read.  
     :type field: tuple of ints.  
+    :param pixel_indices: read only a subset of pixels in RING ordering
+    :type field: array of ints.
     :param verbose: run in verbose mode.  
     :type verbose: bool.
     :returns: numpy.ndarray -- the maps that have been read. 
     """
-    return hp.ud_grade(hp.read_map(fname, field = field, verbose = verbose), nside_out = nside)
+    output_map = hp.ud_grade(hp.read_map(fname, field = field, verbose = verbose), nside_out = nside)
+    if pixel_indices is None:
+        return output_map
+    else:
+        try: # multiple components
+            return [each[pixel_indices] for each in output_map]
+        except IndexError: # single component
+            return output_map[pixel_indices]
 
 def read_key(Class, keyword, dictionary):
     """Gives the input class an attribute with the name of the keyword and

--- a/pysm/components.py
+++ b/pysm/components.py
@@ -393,10 +393,9 @@ class Dust(object):
         #considered.Since nside is not a parameter Sky knows about we have to get it from
         #A_I, which is not ideal.
         uval_map = hp.ud_grade(np.clip((4. + beta) * np.log10(T / np.mean(T)), -3., 5.), nside_out = nside)
-        if pixel_indices:
-            return uval_map[pixel_indices]
-        else:
-            return uval_map
+        if not pixel_indices is None:
+            uval_map = uval_map[pixel_indices]
+        return uval_map
 
     @staticmethod
     def read_hd_data():

--- a/pysm/components.py
+++ b/pysm/components.py
@@ -322,6 +322,14 @@ class Dust(object):
             print("Dust attribute 'Add_Decorrelation' not set.")
             sys.exit(1)
 
+    @property
+    def nside(self):
+        try:
+            return self.__nside
+        except AttributeError:
+            print("Dust attribute 'nside' not set.")
+            sys.exit(1)
+
     def signal(self):
         """Function to return the selected SED.
 
@@ -434,7 +442,7 @@ class Dust(object):
 
         #now draw the random realisation of uval if draw_uval = true
         if self.Draw_Uval:
-            self.Uval = self.draw_uval(self.Draw_Uval_Seed, hp.npix2nside(len(self.A_I)))
+            self.Uval = self.draw_uval(self.Draw_Uval_Seed, self.nside)
         elif not self.Draw_Uval:
             pass
         else:
@@ -492,22 +500,19 @@ class Dust(object):
                 scaling_I = RJ_factor * eval_HD17_I(nu_break, self.Nu_0_I)
                 scaling_P = RJ_factor * eval_HD17_P(nu_break, self.Nu_0_P)
 
-                try:
-                    scaling_I = hp.ud_grade(scaling_I, nside_out = hp.npix2nside(len(self.A_I)))
-                    scaling_P = hp.ud_grade(scaling_P, nside_out = hp.npix2nside(len(self.A_I)))
-                except IndexError:
-                    pass
+            else:
 
-                return np.array([scaling_I * self.A_I, scaling_P * self.A_Q, scaling_P * self.A_U])
-
-            #calculate the intensity scaling from reference frequency
-            #self.Nu_0_I to frequency nu.
-            scaling_I = eval_HD17_I(nu, self.Nu_0_I)
-            scaling_P = eval_HD17_P(nu, self.Nu_0_P)
+                #calculate the intensity scaling from reference frequency
+                #self.Nu_0_I to frequency nu.
+                scaling_I = eval_HD17_I(nu, self.Nu_0_I)
+                scaling_P = eval_HD17_P(nu, self.Nu_0_P)
 
             try:
-                scaling_I = hp.ud_grade(scaling_I, nside_out = hp.npix2nside(len(self.A_I)))
-                scaling_P = hp.ud_grade(scaling_P, nside_out = hp.npix2nside(len(self.A_I)))
+                scaling_I = hp.ud_grade(scaling_I, nside_out = self.nside)
+                scaling_P = hp.ud_grade(scaling_P, nside_out = self.nside)
+                if not self.pixel_indices is None:
+                    scaling_I = scaling_I[self.pixel_indices]
+                    scaling_P = scaling_P[self.pixel_indices]
             except IndexError:
                 pass
             return np.array([scaling_I * self.A_I, scaling_P * self.A_Q, scaling_P * self.A_U])

--- a/pysm/components.py
+++ b/pysm/components.py
@@ -357,7 +357,7 @@ class Dust(object):
         return model
 
     @staticmethod
-    def draw_uval(seed, nside):
+    def draw_uval(seed, nside, pixel_indices=None):
         #Use Planck MBB temperature data to draw realisations of the temperature and spectral
         #index from normal distribution with mean equal to the maximum likelihood commander value,
         # and standard deviation equal to the commander std.
@@ -377,7 +377,11 @@ class Dust(object):
         #to note this for the future). We then udgrade the uval map to whatever nside is being
         #considered.Since nside is not a parameter Sky knows about we have to get it from
         #A_I, which is not ideal.
-        return hp.ud_grade(np.clip((4. + beta) * np.log10(T / np.mean(T)), -3., 5.), nside_out = nside)
+        uval_map = hp.ud_grade(np.clip((4. + beta) * np.log10(T / np.mean(T)), -3., 5.), nside_out = nside)
+        if pixel_indices:
+            return uval_map[pixel_indices]
+        else:
+            return uval_map
 
     @staticmethod
     def read_hd_data():

--- a/pysm/components.py
+++ b/pysm/components.py
@@ -323,6 +323,13 @@ class Dust(object):
             sys.exit(1)
 
     @property
+    def pixel_indices(self):
+        try:
+            return self.__pixel_indices
+        except AttributeError:
+            print("Dust attribute 'pixel_indices' not set.")
+
+    @property
     def nside(self):
         try:
             return self.__nside

--- a/pysm/components.py
+++ b/pysm/components.py
@@ -865,6 +865,13 @@ class CMB(object):
         except AttributeError:
             print("CMB attribute 'A_U' not set.")
 
+    @property
+    def pixel_indices(self):
+        try:
+            return self.__pixel_indices
+        except AttributeError:
+            print("CMB attribute 'pixel_indices' not set.")
+
     def signal(self):
         """Function to return the selected SED.
 
@@ -935,7 +942,11 @@ class CMB(object):
 
         @FloatOrArray
         def model(nu, **kwargs):
-            return np.array(rm) * convert_units("uK_CMB", "uK_RJ", nu)
+            cmb_map = np.array(rm) * convert_units("uK_CMB", "uK_RJ", nu)
+            if self.pixel_indices is None:
+                return cmb_map
+            else:
+                return cmb_map[:, self.pixel_indices]
         return model
 
     def synfast(self):
@@ -964,7 +975,12 @@ class CMB(object):
 
         @FloatOrArray
         def model(nu, **kwargs):
-            return np.array([T, Q, U]) * convert_units("uK_CMB", "uK_RJ", nu)
+            cmb_map = np.array([T, Q, U]) * convert_units("uK_CMB", "uK_RJ", nu)
+            if self.pixel_indices is None:
+                return cmb_map
+            else:
+                return cmb_map[:, self.pixel_indices]
+
         return model
 
     def pre_computed(self):

--- a/pysm/nominal.py
+++ b/pysm/nominal.py
@@ -9,7 +9,8 @@ template = lambda x: os.path.join(data_dir, x)
 
 def models(key, nside, pixel_indices=None):
     model = eval(key)(nside, pixel_indices=pixel_indices)
-    model['pixel_indices'] = pixel_indices # include pixel indices in the model dictionary
+    for m in model:
+        m['pixel_indices'] = pixel_indices # include pixel indices in the model dictionary
     return model
 
 def d0(nside, pixel_indices=None):

--- a/pysm/nominal.py
+++ b/pysm/nominal.py
@@ -11,6 +11,7 @@ def models(key, nside, pixel_indices=None):
     model = eval(key)(nside, pixel_indices=pixel_indices)
     for m in model:
         m['pixel_indices'] = pixel_indices # include pixel indices in the model dictionary
+        m['nside'] = nside
     return model
 
 def d0(nside, pixel_indices=None):

--- a/pysm/nominal.py
+++ b/pysm/nominal.py
@@ -7,85 +7,87 @@ import os
 data_dir = os.path.join(os.path.dirname(__file__), 'template')
 template = lambda x: os.path.join(data_dir, x)
 
-def models(key, nside):
-    return eval(key)(nside)
+def models(key, nside, pixel_indices=None):
+    model = eval(key)(nside, pixel_indices=pixel_indices)
+    model['pixel_indices'] = pixel_indices # include pixel indices in the model dictionary
+    return model
 
-def d0(nside):
+def d0(nside, pixel_indices=None):
     return [{
         'model': 'modified_black_body',
         'nu_0_I': 545.,
         'nu_0_P': 353.,
-        'A_I': read_map(template('dust_t_new.fits'), nside, field=0),
-        'A_Q': read_map(template('dust_q_new.fits'), nside, field=0),
-        'A_U': read_map(template('dust_u_new.fits'), nside, field=0),
-        'spectral_index': np.ones(nside2npix(nside)) * 1.54,
-        'temp': np.ones(nside2npix(nside)) * 20.,
+        'A_I': read_map(template('dust_t_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_Q': read_map(template('dust_q_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_U': read_map(template('dust_u_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'spectral_index': np.ones(nside2npix(nside, pixel_indices=None)) * 1.54,
+        'temp': np.ones(nside2npix(nside, pixel_indices=None)) * 20.,
         'add_decorrelation': False,
     }]
 
-def d1(nside):
+def d1(nside, pixel_indices=None):
     return [{
         'model': 'modified_black_body',
         'nu_0_I': 545.,
         'nu_0_P': 353.,
-        'A_I': read_map(template('dust_t_new.fits'), nside, field=0),
-        'A_Q': read_map(template('dust_q_new.fits'), nside, field=0),
-        'A_U': read_map(template('dust_u_new.fits'), nside, field=0),
-        'spectral_index': read_map(template('dust_beta.fits'), nside=nside, field=0),
-        'temp': read_map(template('dust_temp.fits'), nside, field=0),
+        'A_I': read_map(template('dust_t_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_Q': read_map(template('dust_q_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_U': read_map(template('dust_u_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'spectral_index': read_map(template('dust_beta.fits'), nside=nside, field=0, pixel_indices=pixel_indices),
+        'temp': read_map(template('dust_temp.fits'), nside, field=0, pixel_indices=pixel_indices),
         'add_decorrelation': False,
     }]
 
-def d2(nside):
+def d2(nside, pixel_indices=None):
     return [{
         'model': 'modified_black_body',
         'nu_0_I': 545.,
         'nu_0_P': 353.,
-        'A_I': read_map(template('dust_t_new.fits'), nside, field=0),
-        'A_Q': read_map(template('dust_q_new.fits'), nside, field=0),
-        'A_U': read_map(template('dust_u_new.fits'), nside, field=0),
-        'spectral_index': read_map(template('beta_mean1p59_std0p2.fits'), nside, field=0),
-        'temp': read_map(template('dust_temp.fits'), nside, field=0),
+        'A_I': read_map(template('dust_t_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_Q': read_map(template('dust_q_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_U': read_map(template('dust_u_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'spectral_index': read_map(template('beta_mean1p59_std0p2.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'temp': read_map(template('dust_temp.fits'), nside, field=0, pixel_indices=pixel_indices),
         'add_decorrelation': False,
     }]
 
-def d3(nside):
+def d3(nside, pixel_indices=None):
     return [{
         'model': 'modified_black_body',
         'nu_0_I': 545.,
         'nu_0_P': 353.,
-        'A_I': read_map(template('dust_t_new.fits'), nside, field=0),
-        'A_Q': read_map(template('dust_q_new.fits'), nside, field=0),
-        'A_U': read_map(template('dust_u_new.fits'), nside, field=0),
-        'spectral_index': read_map(template('beta_mean1p59_std0p3.fits'), nside, field=0),
-        'temp': read_map(template('dust_temp.fits'), nside, field=0),
+        'A_I': read_map(template('dust_t_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_Q': read_map(template('dust_q_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_U': read_map(template('dust_u_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'spectral_index': read_map(template('beta_mean1p59_std0p3.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'temp': read_map(template('dust_temp.fits'), nside, field=0, pixel_indices=pixel_indices),
         'add_decorrelation': False,
     }]
 
-def d4(nside):
+def d4(nside, pixel_indices=None):
     return [{
         'model': 'modified_black_body',
         'nu_0_I': 545.,
         'nu_0_P': 353.,
-        'A_I': read_map(template('dust2comp_I1_ns512_545.fits'), nside, field=0),
-        'A_Q': read_map(template('dust2comp_Q1_ns512_353.fits'), nside, field=0),
-        'A_U': read_map(template('dust2comp_U1_ns512_353.fits'), nside, field=0),
-        'spectral_index': read_map(template('dust2comp_beta1_ns512.fits'), nside, field=0),
-        'temp': read_map(template('dust2comp_temp1_ns512.fits'), nside, field=0),
+        'A_I': read_map(template('dust2comp_I1_ns512_545.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_Q': read_map(template('dust2comp_Q1_ns512_353.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_U': read_map(template('dust2comp_U1_ns512_353.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'spectral_index': read_map(template('dust2comp_beta1_ns512.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'temp': read_map(template('dust2comp_temp1_ns512.fits'), nside, field=0, pixel_indices=pixel_indices),
         'add_decorrelation': False,
     }, {
         'model': 'modified_black_body',
         'nu_0_I': 545.,
         'nu_0_P': 353.,
-        'A_I': read_map(template('dust2comp_I2_ns512_545.fits'), nside, field=0),
-        'A_Q': read_map(template('dust2comp_Q2_ns512_353.fits'), nside, field=0),
-        'A_U': read_map(template('dust2comp_U2_ns512_353.fits'), nside, field=0),
-        'spectral_index': read_map(template('dust2comp_beta2_ns512.fits'), nside, field=0),
-        'temp': read_map(template('dust2comp_temp2_ns512.fits'), nside, field=0),
+        'A_I': read_map(template('dust2comp_I2_ns512_545.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_Q': read_map(template('dust2comp_Q2_ns512_353.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_U': read_map(template('dust2comp_U2_ns512_353.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'spectral_index': read_map(template('dust2comp_beta2_ns512.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'temp': read_map(template('dust2comp_temp2_ns512.fits'), nside, field=0, pixel_indices=pixel_indices),
         'add_decorrelation': False,
     }]
 
-def d5(nside):
+def d5(nside, pixel_indices=None):
     return [{
         'model': 'hensley_draine_2017',
         'draw_uval': True,
@@ -94,27 +96,27 @@ def d5(nside):
         'f_fe': 0.,
         'nu_0_I': 545.,
         'nu_0_P': 353.,
-        'A_I': read_map(template('dust_t_new.fits'), nside, field=0),
-        'A_Q': read_map(template('dust_q_new.fits'), nside, field=0),
-        'A_U': read_map(template('dust_u_new.fits'), nside, field=0),
+        'A_I': read_map(template('dust_t_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_Q': read_map(template('dust_q_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_U': read_map(template('dust_u_new.fits'), nside, field=0, pixel_indices=pixel_indices),
         'add_decorrelation': False,
     }]
 
-def d6(nside):
+def d6(nside, pixel_indices=None):
     return [{
         'model': 'modified_black_body',
         'nu_0_I': 545.,
         'nu_0_P': 353.,
-        'A_I': read_map(template('dust_t_new.fits'), nside, field=0),
-        'A_Q': read_map(template('dust_q_new.fits'), nside, field=0),
-        'A_U': read_map(template('dust_u_new.fits'), nside, field=0),
-        'spectral_index': read_map(template('dust_beta.fits'), nside, field=0),
-        'temp': read_map(template('dust_temp.fits'), nside, field=0),
+        'A_I': read_map(template('dust_t_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_Q': read_map(template('dust_q_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_U': read_map(template('dust_u_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'spectral_index': read_map(template('dust_beta.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'temp': read_map(template('dust_temp.fits'), nside, field=0, pixel_indices=pixel_indices),
         'add_decorrelation': True,
         'corr_len': 5.0
     }]
 
-def d7(nside):
+def d7(nside, pixel_indices=None):
     return [{
         'model': 'hensley_draine_2017',
         'draw_uval': True,
@@ -123,13 +125,13 @@ def d7(nside):
         'f_fe': 0.44,
         'nu_0_I': 545.,
         'nu_0_P': 353.,
-        'A_I': read_map(template('dust_t_new.fits'), nside, field=0),
-        'A_Q': read_map(template('dust_q_new.fits'), nside, field=0),
-        'A_U': read_map(template('dust_u_new.fits'), nside, field=0),
+        'A_I': read_map(template('dust_t_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_Q': read_map(template('dust_q_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_U': read_map(template('dust_u_new.fits'), nside, field=0, pixel_indices=pixel_indices),
         'add_decorrelation' : False,
     }]
 
-def d8(nside):
+def d8(nside, pixel_indices=None):
     return [{
         'model': 'hensley_draine_2017',
         'draw_uval': False,
@@ -139,67 +141,67 @@ def d8(nside):
         'f_fe': 0.44,
         'nu_0_I': 545.,
         'nu_0_P': 353.,
-        'A_I': read_map(template('dust_t_new.fits'), nside, field=0),
-        'A_Q': read_map(template('dust_q_new.fits'), nside, field=0),
-        'A_U': read_map(template('dust_u_new.fits'), nside, field=0),
+        'A_I': read_map(template('dust_t_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_Q': read_map(template('dust_q_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_U': read_map(template('dust_u_new.fits'), nside, field=0, pixel_indices=pixel_indices),
         'add_decorrelation': False,
     }]
 
-def s0(nside):
+def s0(nside, pixel_indices=None):
     return [{
         'model': 'power_law',
         'nu_0_I': 0.408,
         'nu_0_P': 23.,
-        'A_I': read_map(template('synch_t_new.fits'), nside, field=0),
-        'A_Q': read_map(template('synch_q_new.fits'), nside, field=0),
-        'A_U': read_map(template('synch_u_new.fits'), nside, field=0),
-        'spectral_index': np.ones(nside2npix(nside)) * -3,
+        'A_I': read_map(template('synch_t_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_Q': read_map(template('synch_q_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_U': read_map(template('synch_u_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'spectral_index': np.ones(nside2npix(nside, pixel_indices=None)) * -3,
     }]
 
-def s1(nside):
+def s1(nside, pixel_indices=None):
     return [{
         'model': 'power_law',
         'nu_0_I': 0.408,
         'nu_0_P': 23.,
-        'A_I': read_map(template('synch_t_new.fits'), nside, field=0),
-        'A_Q': read_map(template('synch_q_new.fits'), nside, field=0),
-        'A_U': read_map(template('synch_u_new.fits'), nside, field=0),
-        'spectral_index': read_map(template('synch_beta.fits'), nside, field=0),
+        'A_I': read_map(template('synch_t_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_Q': read_map(template('synch_q_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_U': read_map(template('synch_u_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'spectral_index': read_map(template('synch_beta.fits'), nside, field=0, pixel_indices=pixel_indices),
     }]
 
-def s2(nside):
+def s2(nside, pixel_indices=None):
     return [{
         'model': 'power_law',
         'nu_0_I': 0.408,
         'nu_0_P': 23.,
-        'A_I': read_map(template('synch_t_new.fits'), nside, field=0),
-        'A_Q': read_map(template('synch_q_new.fits'), nside, field=0),
-        'A_U': read_map(template('synch_u_new.fits'), nside, field=0),
-        'spectral_index': read_map(template('beta_latvar.fits'), nside, field=0),
+        'A_I': read_map(template('synch_t_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_Q': read_map(template('synch_q_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_U': read_map(template('synch_u_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'spectral_index': read_map(template('beta_latvar.fits'), nside, field=0, pixel_indices=pixel_indices),
     }]
 
-def s3(nside):
+def s3(nside, pixel_indices=None):
     return [{
         'model': 'curved_power_law',
         'nu_0_I': 0.408,
         'nu_0_P': 23.,
-        'A_I': read_map(template('synch_t_new.fits'), nside, field=0),
-        'A_Q': read_map(template('synch_q_new.fits'), nside, field=0),
-        'A_U': read_map(template('synch_u_new.fits'), nside, field=0),
-        'spectral_index': read_map(template('synch_beta.fits'), nside, field=0),
+        'A_I': read_map(template('synch_t_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_Q': read_map(template('synch_q_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_U': read_map(template('synch_u_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'spectral_index': read_map(template('synch_beta.fits'), nside, field=0, pixel_indices=pixel_indices),
         'spectral_curvature': -0.052,
         'nu_curve': 23.,
     }]
 
-def f1(nside):
+def f1(nside, pixel_indices=None):
     return [{
         'model': 'power_law',
         'nu_0_I': 30.,
-        'A_I': read_map(template('ff_t_new.fits'), nside, field=0),
+        'A_I': read_map(template('ff_t_new.fits'), nside, field=0, pixel_indices=pixel_indices),
         'spectral_index': -2.14,
     }]
 
-def c1(nside):
+def c1(nside, pixel_indices=None):
     return [{
         'model': 'taylens',
         'cmb_specs': np.loadtxt(template('camb_lenspotentialCls.dat'), unpack=True),
@@ -209,44 +211,44 @@ def c1(nside):
         'cmb_seed': 1111
     }]
 
-def a1(nside):
+def a1(nside, pixel_indices=None):
     return [{
         'model': 'spdust',
         'nu_0_I': 22.8,
         'nu_0_P': 22.8,
-        'A_I': read_map(template('ame_t_new.fits'), nside, field=0),
+        'A_I': read_map(template('ame_t_new.fits'), nside, field=0, pixel_indices=pixel_indices),
         'nu_peak_0': 30.,
         'emissivity': np.loadtxt(template('emissivity.txt'), unpack=True),
-        'nu_peak': read_map(template('ame_nu_peak_0.fits'), nside, field=0),
+        'nu_peak': read_map(template('ame_nu_peak_0.fits'), nside, field=0, pixel_indices=pixel_indices),
     }, {
         'model': 'spdust',
         'nu_0_I': 41.0,
         'nu_0_P': 41.0,
-        'A_I': read_map(template('ame2_t_new.fits'), nside, field=0),
+        'A_I': read_map(template('ame2_t_new.fits'), nside, field=0, pixel_indices=pixel_indices),
         'nu_peak_0': 30.,
         'emissivity': np.loadtxt(template('emissivity.txt'), unpack=True),
         'nu_peak': 33.35
     }]
 
-def a2(nside):
+def a2(nside, pixel_indices=None):
     return [{
         'model': 'spdust_pol',
         'nu_0_I': 22.8,
-        'A_I': read_map(template('ame_t_new.fits'), nside, field=0),
+        'A_I': read_map(template('ame_t_new.fits'), nside, field=0, pixel_indices=pixel_indices),
         'nu_peak_0': 30.,
         'emissivity': np.loadtxt(template('emissivity.txt'), unpack=True),
-        'nu_peak': read_map(template('ame_nu_peak_0.fits'), nside, field=0),
+        'nu_peak': read_map(template('ame_nu_peak_0.fits'), nside, field=0, pixel_indices=pixel_indices),
         'pol_frac': 0.02,
-        'angle_q': read_map(template('dust_q_new.fits'), nside, field=0),
-        'angle_u': read_map(template('dust_u_new.fits'), nside, field=0)
+        'angle_q': read_map(template('dust_q_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'angle_u': read_map(template('dust_u_new.fits'), nside, field=0, pixel_indices=pixel_indices)
     }, {
         'model': 'spdust_pol',
         'nu_0_I': 41.0,
-        'A_I': read_map(template('ame2_t_new.fits'), nside, field=0),
+        'A_I': read_map(template('ame2_t_new.fits'), nside, field=0, pixel_indices=pixel_indices),
         'nu_peak_0': 30.,
         'emissivity': np.loadtxt(template('emissivity.txt'), unpack=True),
         'nu_peak': 33.35,
         'pol_frac': 0.02,
-        'angle_q': read_map(template('dust_q_new.fits'), nside, field=0),
-        'angle_u': read_map(template('dust_u_new.fits'), nside, field=0)
+        'angle_q': read_map(template('dust_q_new.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'angle_u': read_map(template('dust_u_new.fits'), nside, field=0, pixel_indices=pixel_indices)
     }]

--- a/pysm/pysm.py
+++ b/pysm/pysm.py
@@ -303,6 +303,13 @@ class Instrument(object):
         except AttributeError:
             print("Instrument attribute 'Output_Units not set.'")
             
+    @property
+    def pixel_indices(self):
+        try:
+            return self.__pixel_indices
+        except AttributeError:
+            print("Instrument attribute 'pixel_indices' not set.")
+
     def observe(self, Sky):
         """Evaluate and add instrument effects to Sky's signal function.
 
@@ -391,7 +398,11 @@ class Instrument(object):
         :return: map plus noise, and noise -- numpy.ndarray
 
         """
-        npix = hp.nside2npix(self.Nside)
+        try:
+            npix = len(self.pixel_indices)
+        except TypeError:
+            npix = hp.nside2npix(self.Nside)
+
         if not self.Add_Noise:
             return np.zeros((len(self.Sens_I), 3, npix))
         elif self.Add_Noise:

--- a/pysm/pysm.py
+++ b/pysm/pysm.py
@@ -582,7 +582,7 @@ def initialise_hd_dust_model_bandpass(hd_unint_signal, **kwargs):
 
     """
     #Draw map of uval using Commander dust data.
-    uval = Dust.draw_uval(kwargs['draw_uval_seed'], hp.npix2nside(len(kwargs['A_I'])))
+    uval = Dust.draw_uval(kwargs['draw_uval_seed'], kwargs['nside'], kwargs.get('pixel_indices'))
 
     #Read in the precomputed dust emission spectra as a function of lambda and U.
     data_sil, data_silfe, data_car, wav, uvec = Dust.read_hd_data()

--- a/pysm/pysm.py
+++ b/pysm/pysm.py
@@ -310,7 +310,7 @@ class Instrument(object):
         except AttributeError:
             print("Instrument attribute 'pixel_indices' not set.")
 
-    def observe(self, Sky):
+    def observe(self, Sky, write_outputs=True):
         """Evaluate and add instrument effects to Sky's signal function.
 
         This method evaluates the Sky class's signal method at the
@@ -329,7 +329,10 @@ class Instrument(object):
         output = self.smoother(output)
         noise = self.noiser()
         output, noise = self.unit_converter(output, noise)
-        self.writer(output, noise)
+        if write_outputs:
+            self.writer(output, noise)
+        else:
+            return output, noise
         return 
         
     def apply_bandpass(self, signal, Sky):

--- a/pysm/pysm.py
+++ b/pysm/pysm.py
@@ -473,19 +473,19 @@ class Instrument(object):
                 for f, o, n in zip(self.Frequencies, output, noise):
                     print(np.std(n, axis = 1))# * np.sqrt(4. * np.pi / float(hp.nside2npix(128)) * (180. * 60. / np.pi) ** 2)
                     print(np.std(o, axis = 1))
-                    hp.write_map(self.file_path(f = f, extra_info = "noise"), n)
-                    hp.write_map(self.file_path(f = f, extra_info = "total"), o + n)
+                    hp.write_map(self.file_path(f = f, extra_info = "noise"), n, overwrite=True)
+                    hp.write_map(self.file_path(f = f, extra_info = "total"), o + n, overwrite=True)
             elif not self.Add_Noise:
                 for f, o in zip(self.Frequencies, output):
-                    hp.write_map(self.file_path(f = f, extra_info = "total"), o)
+                    hp.write_map(self.file_path(f = f, extra_info = "total"), o, overwrite=True)
         elif self.Use_Bandpass:
             if self.Add_Noise:
                 for c, o, n in zip(self.Channel_Names, output, noise):
-                    hp.write_map(self.file_path(channel_name = c, extra_info = "total"), o + n)
-                    hp.write_map(self.file_path(channel_name = c, extra_info = "noise"), n)
+                    hp.write_map(self.file_path(channel_name = c, extra_info = "total"), o + n, overwrite=True)
+                    hp.write_map(self.file_path(channel_name = c, extra_info = "noise"), n, overwrite=True)
             elif not self.Add_Noise:
                 for c, o in zip(self.Channel_Names, output):
-                    hp.write_map(self.file_path(channel_name = c, extra_info = "total"), o)
+                    hp.write_map(self.file_path(channel_name = c, extra_info = "total"), o, overwrite=True)
         return
 
     def print_info(self):

--- a/pysm/pysm.py
+++ b/pysm/pysm.py
@@ -410,7 +410,7 @@ class Instrument(object):
             return np.zeros((len(self.Sens_I), 3, npix))
         elif self.Add_Noise:
             # solid angle per pixel in amin2
-            pix_amin2 = 4. * np.pi / float(npix) * (180. * 60. / np.pi) ** 2
+            pix_amin2 = 4. * np.pi / float(hp.nside2npix(self.Nside)) * (180. * 60. / np.pi) ** 2
             """sigma_pix_I/P is std of noise per pixel. It is an array of length
             equal to the number of input maps."""
             sigma_pix_I = np.sqrt(self.Sens_I ** 2 / pix_amin2)

--- a/test/test_pysm.py
+++ b/test/test_pysm.py
@@ -96,7 +96,7 @@ class TestNoise(unittest.TestCase):
         
     def test_noise_partialsky(self):
         local_instrument_config = self.instrument_config.copy()
-        local_instrument_config["pixel_indices"] = np.arange(100, dtype=np.int)
+        local_instrument_config["pixel_indices"] = np.arange(20000, dtype=np.int)
         instrument = pysm.Instrument(local_instrument_config)
         noise = instrument.noiser()
 

--- a/test/test_pysm.py
+++ b/test/test_pysm.py
@@ -74,14 +74,17 @@ class TestNoise(unittest.TestCase):
 
         self.expected_T_std = sigma_T / pix2amin
         self.expected_P_std = sigma_P / pix2amin
+        self.test_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_nu0023p00GHz_noise_nside%04d.fits"%self.nside)
 
     def tearDown(self):
-        os.remove(self.test_file)
+        try:
+            os.remove(self.test_file)
+        except: # exception is different on different Python versions
+            pass
         
     def test_noise(self):
         instrument = pysm.Instrument(self.instrument_config)
         instrument.observe(self.sky)
-        self.test_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_nu0023p00GHz_noise_nside%04d.fits"%self.nside)
         T, Q, U = pysm.read_map(self.test_file, self.nside, field = (0, 1, 2))
         T_std = np.std(T)
         Q_std = np.std(Q)

--- a/test/test_pysm.py
+++ b/test/test_pysm.py
@@ -94,6 +94,16 @@ class TestNoise(unittest.TestCase):
         np.testing.assert_almost_equal(Q_std, self.expected_P_std, decimal = 2)
         np.testing.assert_almost_equal(U_std, self.expected_P_std, decimal = 2)
         
+    def test_noise_partialsky(self):
+        local_instrument_config = self.instrument_config.copy()
+        local_instrument_config["pixel_indices"] = np.arange(100, dtype=np.int)
+        instrument = pysm.Instrument(local_instrument_config)
+        noise = instrument.noiser()
+
+        assert noise[0].shape == (3, len(local_instrument_config["pixel_indices"]))
+        np.testing.assert_almost_equal(np.std(noise[0][0]), self.expected_T_std, decimal = 2)
+        np.testing.assert_almost_equal(np.std(noise[0][1]), self.expected_P_std, decimal = 2)
+        np.testing.assert_almost_equal(np.std(noise[0][2]), self.expected_P_std, decimal = 2)
         
 def main():
     unittest.main()

--- a/test/test_pysm.py
+++ b/test/test_pysm.py
@@ -47,14 +47,14 @@ class testCheck_Bandpass_Frequencies(unittest.TestCase):
         
 class TestNoise(unittest.TestCase):
     def setUp(self):
-        nside = 1024
+        self.nside = 1024
         sigma_T = 4.
         sigma_P = np.sqrt(2.) * sigma_T
         instrument_config = {
                 'frequencies' : np.array([23.]),
                 'sens_I' : np.array([sigma_T]),
                 'sens_P' : np.array([sigma_P]),
-                'nside' : nside,
+                'nside' : self.nside,
                 'noise_seed' : 1234,
                 'use_bandpass' : False,
                 'add_noise' : True,
@@ -63,33 +63,33 @@ class TestNoise(unittest.TestCase):
                 'output_directory' : os.path.dirname(os.path.abspath(__file__)),
                 'output_prefix' : 'test',
             }
-        s1 = models("s1", nside)
-        s1[0]['A_I'] = np.zeros(hp.nside2npix(nside))
-        s1[0]['A_Q'] = np.zeros(hp.nside2npix(nside))
-        s1[0]['A_U'] = np.zeros(hp.nside2npix(nside))
+        s1 = models("s1", self.nside)
+        s1[0]['A_I'] = np.zeros(hp.nside2npix(self.nside))
+        s1[0]['A_Q'] = np.zeros(hp.nside2npix(self.nside))
+        s1[0]['A_U'] = np.zeros(hp.nside2npix(self.nside))
         sky_config = {'synchrotron' : s1}
-        sky = pysm.Sky(sky_config)
-        instrument = pysm.Instrument(instrument_config)
-        instrument.observe(sky)
-        self.test_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_nu0023p00GHz_noise_nside%04d.fits"%nside)
-        T, Q, U = pysm.read_map(self.test_file, nside, field = (0, 1, 2))
+        self.sky = pysm.Sky(sky_config)
+        self.instrument = pysm.Instrument(instrument_config)
+        
+        pix2amin = np.sqrt(4. * np.pi * (180. / np.pi * 60.) ** 2 / float(hp.nside2npix(self.nside)))
+
+        self.expected_T_std = sigma_T / pix2amin
+        self.expected_P_std = sigma_P / pix2amin
+
+    def tearDown(self):
+        os.remove(self.test_file)
+        
+    def test_noise(self):
+        self.instrument.observe(self.sky)
+        self.test_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_nu0023p00GHz_noise_nside%04d.fits"%self.nside)
+        T, Q, U = pysm.read_map(self.test_file, self.nside, field = (0, 1, 2))
         T_std = np.std(T)
         Q_std = np.std(Q)
         U_std = np.std(U)
-        
-        pix2amin = np.sqrt(4. * np.pi * (180. / np.pi * 60.) ** 2 / float(hp.nside2npix(nside)))
-        
-        self.check_T = T_std * pix2amin / sigma_T
-        self.check_Q = Q_std * pix2amin / sigma_P
-        self.check_U = U_std * pix2amin / sigma_P
 
-    def tearDown(self):
-        os.system("rm %s"%self.test_file)
-        
-    def test_noise(self):
-        np.testing.assert_almost_equal(self.check_T, 1., decimal = 2)
-        np.testing.assert_almost_equal(self.check_Q, 1., decimal = 2)
-        np.testing.assert_almost_equal(self.check_U, 1., decimal = 2)
+        np.testing.assert_almost_equal(T_std, self.expected_T_std, decimal = 2)
+        np.testing.assert_almost_equal(Q_std, self.expected_P_std, decimal = 2)
+        np.testing.assert_almost_equal(U_std, self.expected_P_std, decimal = 2)
         
         
 def main():

--- a/test/test_pysm.py
+++ b/test/test_pysm.py
@@ -50,7 +50,7 @@ class TestNoise(unittest.TestCase):
         self.nside = 1024
         sigma_T = 4.
         sigma_P = np.sqrt(2.) * sigma_T
-        instrument_config = {
+        self.instrument_config = {
                 'frequencies' : np.array([23.]),
                 'sens_I' : np.array([sigma_T]),
                 'sens_P' : np.array([sigma_P]),
@@ -69,7 +69,6 @@ class TestNoise(unittest.TestCase):
         s1[0]['A_U'] = np.zeros(hp.nside2npix(self.nside))
         sky_config = {'synchrotron' : s1}
         self.sky = pysm.Sky(sky_config)
-        self.instrument = pysm.Instrument(instrument_config)
         
         pix2amin = np.sqrt(4. * np.pi * (180. / np.pi * 60.) ** 2 / float(hp.nside2npix(self.nside)))
 
@@ -80,7 +79,8 @@ class TestNoise(unittest.TestCase):
         os.remove(self.test_file)
         
     def test_noise(self):
-        self.instrument.observe(self.sky)
+        instrument = pysm.Instrument(self.instrument_config)
+        instrument.observe(self.sky)
         self.test_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_nu0023p00GHz_noise_nside%04d.fits"%self.nside)
         T, Q, U = pysm.read_map(self.test_file, self.nside, field = (0, 1, 2))
         T_std = np.std(T)


### PR DESCRIPTION
Work In Progress

I am following #10 (thanks @bthorne93, your instructions were very clear!) to implement support for partial sky, for now I have implemented support in handling standard components, CMB and `hensley_draine_2017` Dust.

I am missing modifying what is related to the instrument, I'll work on that in the next days.

See partial sky support testing here (I can add the notebook to the repo once this is done): http://nbviewer.jupyter.org/gist/zonca/2ba1a145b150a73a427fd21b2ff82034

You can already start reviewing this as I go.