### PR TITLE
precomputed CMB model

### DIFF
--- a/pysm/nominal.py
+++ b/pysm/nominal.py
@@ -213,6 +213,15 @@ def c1(nside, pixel_indices=None):
         'cmb_seed': 1111
     }]
 
+def c2(nside, pixel_indices=None):
+    return [{
+        'model': 'pre_computed',
+        'A_I': read_map(template('lensed_cmb.fits'), nside, field=0, pixel_indices=pixel_indices),
+        'A_Q': read_map(template('lensed_cmb.fits'), nside, field=1, pixel_indices=pixel_indices),
+        'A_U': read_map(template('lensed_cmb.fits'), nside, field=2, pixel_indices=pixel_indices),
+        'nside': nside
+    }]
+
 def a1(nside, pixel_indices=None):
     return [{
         'model': 'spdust',


### PR DESCRIPTION
@bthorne93 I noticed that the CMB class supports precomputed CMB and there is a `lensed_cmb.fits` map in the data folder. However that is not used in the code.

Would it be useful to add a `c2` model that uses that?