### PR TITLE
Make it easier to add a custom emission

### DIFF
--- a/pysm/pysm.py
+++ b/pysm/pysm.py
@@ -119,6 +119,20 @@ class Sky(object):
             return sig
         return signal
 
+    def add_component(self, name, component):
+        """Add a already initialized component object to the sky
+
+        Parameters
+        ==========
+        name : str
+            name of the new component, it cannot include spaces or commas
+        component : object
+            object that provides a signal(nu, **kwargs) function that returns the emission in uK_RJ
+        """
+        self.__components.append(name)
+        setattr(self, name, component.signal)
+
+
 class Instrument(object):
     """This class contains the attributes and methods required to model
     the instrument observing Sky.

--- a/pysm/test/test_components.py
+++ b/pysm/test/test_components.py
@@ -2,7 +2,10 @@ import unittest, os
 from pysm import components, common, read_map, convert_units
 from pysm import get_template_dir
 
-from astropy.analytic_functions import blackbody_nu
+try:
+    from astropy.analytic_functions import blackbody_nu
+except ImportError:
+    from astropy.modeling.blackbody import blackbody_nu
 import numpy as np, healpy as hp
 import matplotlib.pyplot as plt
 import scipy.constants as constants


### PR DESCRIPTION
the `add_component` allows the user to define a new emission.

This emission only needs to provide a `signal(nu, **kwargs)` method that returns the emission in `uK_RJ`, the input `component` is **not a class** but a already initialized object, already with the correct `nside`, `pixel_indices` and so on.